### PR TITLE
feat: 添加 multipart/form-data 请求体摘要解析并补充测试覆盖

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -6,17 +6,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"strings"
 	"time"
 )
 
 // RequestId 是用于跟踪请求的HTTP头字段名称
 // RequestId is the HTTP header field name used for request tracking
 const RequestId = "Request-Id"
-
-// dateTime 是统计信息中使用的时间格式
-// dateTime is the time format used in statistics
-const dateTime = "2006-01-02 15:04:05.000"
 
 // Stat 是HTTP请求统计信息结构，记录了请求和响应的完整信息
 // 该结构在客户端和服务器端都可以使用，但某些字段的含义略有不同
@@ -198,7 +198,7 @@ func (stat *Stat) Print() string {
 //   - *Stat: 统计信息对象 / Statistics object
 func responseLoad(resp *Response) *Stat {
 	stat := &Stat{
-		StartAt: resp.StartAt.Format(dateTime),
+		StartAt: resp.StartAt.Format(time.RFC3339),
 		Cost:    time.Since(resp.StartAt).Milliseconds(),
 	}
 	if resp.Response != nil {
@@ -263,6 +263,39 @@ func responseLoad(resp *Response) *Stat {
 	return stat
 }
 
+// multipartBodySummary 将 multipart/form-data 请求体表示为 "name=@filename" 或 "name=value"，不记录文件内容
+// multipartBodySummary represents multipart/form-data body as name=@filename or name=value, without recording file content
+func multipartBodySummary(buf *bytes.Buffer, contentType string) string {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil || params["boundary"] == "" {
+		return ""
+	}
+	mr := multipart.NewReader(bytes.NewReader(buf.Bytes()), params["boundary"])
+	var parts []string
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return ""
+		}
+		name := p.FormName()
+		if name == "" {
+			continue
+		}
+		if filename := p.FileName(); filename != "" {
+			parts = append(parts, name+"=@"+filename)
+		} else {
+			var sb strings.Builder
+			if _, err := io.Copy(&sb, p); err == nil {
+				parts = append(parts, name+"="+sb.String())
+			}
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
 // serveLoad 从HTTP请求和响应中提取并构建统计信息（服务器端使用）
 // 该函数会记录服务器端的请求处理统计信息
 //
@@ -291,11 +324,20 @@ func serveLoad(w *ResponseWriter, r *http.Request, start time.Time, buf *bytes.B
 	stat.Request.URL = r.URL.String()
 
 	if buf != nil {
-		m := make(map[string]any)
-		if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-			stat.Request.Body = buf.String()
+		contentType := r.Header.Get("Content-Type")
+		if strings.HasPrefix(contentType, "multipart/form-data") {
+			if summary := multipartBodySummary(buf, contentType); summary != "" {
+				stat.Request.Body = summary
+			} else {
+				stat.Request.Body = "(multipart)"
+			}
 		} else {
-			stat.Request.Body = m
+			m := make(map[string]any)
+			if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+				stat.Request.Body = buf.String()
+			} else {
+				stat.Request.Body = m
+			}
 		}
 	}
 	scheme := "http://"

--- a/stat_test.go
+++ b/stat_test.go
@@ -6,12 +6,191 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// TestMultipartBodySummary 测试 multipartBodySummary 函数
+func TestMultipartBodySummary(t *testing.T) {
+	// buildMultipart 辅助函数：构造 multipart body 和 Content-Type
+	buildMultipart := func(fields map[string]string, files map[string]string) (*bytes.Buffer, string) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		for name, value := range fields {
+			_ = writer.WriteField(name, value)
+		}
+		for fieldName, fileName := range files {
+			part, _ := writer.CreateFormFile(fieldName, fileName)
+			_, _ = part.Write([]byte("fake file content"))
+		}
+		_ = writer.Close()
+		return &buf, writer.FormDataContentType()
+	}
+
+	tests := []struct {
+		name        string
+		buildInput  func() (*bytes.Buffer, string)
+		checkResult func(t *testing.T, result string)
+	}{
+		{
+			name: "单个文本字段",
+			buildInput: func() (*bytes.Buffer, string) {
+				return buildMultipart(map[string]string{"username": "alice"}, nil)
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "username=alice" {
+					t.Errorf("期望 'username=alice'，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "多个文本字段",
+			buildInput: func() (*bytes.Buffer, string) {
+				var buf bytes.Buffer
+				writer := multipart.NewWriter(&buf)
+				// 按顺序写入以保证顺序一致
+				_ = writer.WriteField("name", "bob")
+				_ = writer.WriteField("age", "30")
+				_ = writer.Close()
+				return &buf, writer.FormDataContentType()
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "name=bob&age=30" {
+					t.Errorf("期望 'name=bob&age=30'，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "单个文件上传",
+			buildInput: func() (*bytes.Buffer, string) {
+				return buildMultipart(nil, map[string]string{"avatar": "photo.png"})
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "avatar=@photo.png" {
+					t.Errorf("期望 'avatar=@photo.png'，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "混合字段和文件",
+			buildInput: func() (*bytes.Buffer, string) {
+				var buf bytes.Buffer
+				writer := multipart.NewWriter(&buf)
+				_ = writer.WriteField("title", "my doc")
+				part, _ := writer.CreateFormFile("file", "document.pdf")
+				_, _ = part.Write([]byte("pdf content"))
+				_ = writer.Close()
+				return &buf, writer.FormDataContentType()
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "title=my doc&file=@document.pdf" {
+					t.Errorf("期望 'title=my doc&file=@document.pdf'，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "无效的Content-Type",
+			buildInput: func() (*bytes.Buffer, string) {
+				return bytes.NewBufferString("some data"), "text/plain"
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("无效 Content-Type 应返回空字符串，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "无boundary的Content-Type",
+			buildInput: func() (*bytes.Buffer, string) {
+				return bytes.NewBufferString("some data"), "multipart/form-data"
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("无 boundary 应返回空字符串，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "无法解析的Content-Type",
+			buildInput: func() (*bytes.Buffer, string) {
+				return bytes.NewBufferString("data"), ";;;invalid;;;"
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("无法解析的 Content-Type 应返回空字符串，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "boundary不匹配的无效body",
+			buildInput: func() (*bytes.Buffer, string) {
+				return bytes.NewBufferString("not a valid multipart body"),
+					"multipart/form-data; boundary=nonexistent"
+			},
+			checkResult: func(t *testing.T, result string) {
+				// 没有有效的 part，应返回空字符串（parts 为空，Join 后为 ""）
+				if result != "" {
+					t.Errorf("无效 body 应返回空字符串，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "空的multipart body",
+			buildInput: func() (*bytes.Buffer, string) {
+				var buf bytes.Buffer
+				writer := multipart.NewWriter(&buf)
+				_ = writer.Close() // 关闭但不写入任何 part
+				return &buf, writer.FormDataContentType()
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("空 multipart body 应返回空字符串，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "多个文件上传",
+			buildInput: func() (*bytes.Buffer, string) {
+				var buf bytes.Buffer
+				writer := multipart.NewWriter(&buf)
+				part1, _ := writer.CreateFormFile("file1", "a.txt")
+				_, _ = part1.Write([]byte("aaa"))
+				part2, _ := writer.CreateFormFile("file2", "b.jpg")
+				_, _ = part2.Write([]byte("bbb"))
+				_ = writer.Close()
+				return &buf, writer.FormDataContentType()
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "file1=@a.txt&file2=@b.jpg" {
+					t.Errorf("期望 'file1=@a.txt&file2=@b.jpg'，实际 '%s'", result)
+				}
+			},
+		},
+		{
+			name: "字段值为空字符串",
+			buildInput: func() (*bytes.Buffer, string) {
+				return buildMultipart(map[string]string{"empty": ""}, nil)
+			},
+			checkResult: func(t *testing.T, result string) {
+				if result != "empty=" {
+					t.Errorf("期望 'empty='，实际 '%s'", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, contentType := tt.buildInput()
+			result := multipartBodySummary(buf, contentType)
+			tt.checkResult(t, result)
+		})
+	}
+}
 
 // TestStat_Methods 测试 Stat 的基础方法：String、Print、RequestBody、ResponseBody
 func TestStat_Methods(t *testing.T) {
@@ -378,6 +557,66 @@ func TestServeLoad(t *testing.T) {
 					t.Error("无效 JSON 应存储为字符串")
 				} else if bodyStr != "invalid json" {
 					t.Errorf("请求体不匹配，期望 'invalid json'，实际 '%s'", bodyStr)
+				}
+			},
+		},
+		{
+			name: "multipart/form-data请求_summary成功",
+			buildReq: func() (*http.Request, *ResponseWriter, *bytes.Buffer) {
+				// 构造有效的 multipart body
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("username", "alice")
+				part, _ := writer.CreateFormFile("avatar", "photo.png")
+				_, _ = part.Write([]byte("fake image data"))
+				_ = writer.Close()
+
+				contentType := writer.FormDataContentType()
+				req, _ := http.NewRequest("POST", "/upload", nil)
+				req.Header.Set("Content-Type", contentType)
+				req.RemoteAddr = "10.0.0.1:9090"
+				w := &ResponseWriter{
+					StatusCode: 200,
+					Content:    bytes.NewBufferString(`{"ok":true}`),
+				}
+				buf := bytes.NewBuffer(body.Bytes())
+				return req, w, buf
+			},
+			checkFunc: func(t *testing.T, stat *Stat) {
+				bodyStr, ok := stat.Request.Body.(string)
+				if !ok {
+					t.Fatalf("multipart 请求体应为字符串，实际类型 %T", stat.Request.Body)
+				}
+				if !strings.Contains(bodyStr, "username=alice") {
+					t.Errorf("应包含 'username=alice'，实际 '%s'", bodyStr)
+				}
+				if !strings.Contains(bodyStr, "avatar=@photo.png") {
+					t.Errorf("应包含 'avatar=@photo.png'，实际 '%s'", bodyStr)
+				}
+			},
+		},
+		{
+			name: "multipart/form-data请求_summary失败回退",
+			buildReq: func() (*http.Request, *ResponseWriter, *bytes.Buffer) {
+				// 构造 Content-Type 是 multipart/form-data 但 body 内容无效的情况
+				contentType := "multipart/form-data; boundary=invalidboundary"
+				req, _ := http.NewRequest("POST", "/upload", nil)
+				req.Header.Set("Content-Type", contentType)
+				req.RemoteAddr = "10.0.0.1:9090"
+				w := &ResponseWriter{
+					StatusCode: 400,
+					Content:    bytes.NewBufferString("bad request"),
+				}
+				buf := bytes.NewBufferString("this is not valid multipart data")
+				return req, w, buf
+			},
+			checkFunc: func(t *testing.T, stat *Stat) {
+				bodyStr, ok := stat.Request.Body.(string)
+				if !ok {
+					t.Fatalf("无效 multipart 请求体应为字符串，实际类型 %T", stat.Request.Body)
+				}
+				if bodyStr != "(multipart)" {
+					t.Errorf("期望 '(multipart)'，实际 '%s'", bodyStr)
 				}
 			},
 		},


### PR DESCRIPTION
- 新增 multipartBodySummary 函数，将 multipart 请求体摘要为 name=value&file=@filename 格式
- serveLoad 中按 Content-Type 区分处理 multipart 和 JSON 请求体
- 移除自定义 dateTime 常量，统一使用 time.RFC3339
- 新增 TestMultipartBodySummary（11 个子用例）和 TestServeLoad multipart 分支测试（2 个子用例）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-stat serialization by adding multipart body summarization (including field values and filenames) and switching client-side `StartAt` to RFC3339, which may affect log/metric consumers and data exposure expectations.
> 
> **Overview**
> Adds multipart/form-data awareness to server-side request stats: `serveLoad` now detects multipart bodies and records a lightweight summary (`field=value` / `field=@filename`) instead of attempting JSON parsing, falling back to `"(multipart)"` when parsing fails.
> 
> Client-side stats formatting is adjusted by switching `responseLoad` timestamps to `time.RFC3339` (removing the custom format constant).
> 
> Expands test coverage with a dedicated `TestMultipartBodySummary` suite plus multipart-specific `serveLoad` cases to validate both the summary and fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9815c083ed60fe6c506076162d54d060e25cce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->