### PR TITLE
feat: add ConnTimeout option, improve GenId entropy and refine logging

### DIFF
--- a/options.go
+++ b/options.go
@@ -54,9 +54,10 @@ type Options struct {
 	Cookies  []http.Cookie // HTTP Cookies
 
 	// ===== 客户端配置 / Client Configuration =====
-	Timeout  time.Duration // 请求超时时间 / Request timeout
-	MaxConns int           // 最大连接数（连接池大小）/ Maximum connections (connection pool size)
-	Verify   bool          // 是否验证TLS证书 / Whether to verify TLS certificates
+	Timeout     time.Duration // 请求超时时间（整个请求的总超时）/ Request timeout (total timeout for the whole request)
+	ConnTimeout time.Duration // TCP 连接建立超时（拨号超时）/ TCP connection establishment timeout (dial timeout)
+	MaxConns    int           // 最大连接数（连接池大小）/ Maximum connections (connection pool size)
+	Verify      bool          // 是否验证TLS证书 / Whether to verify TLS certificates
 
 	// ===== 传输层配置 / Transport Layer Configuration =====
 	Transport        http.RoundTripper                           // 自定义传输层 / Custom transport
@@ -114,12 +115,13 @@ type Option func(*Options)
 //   - Options: 合并后的配置选项 / Merged configuration options
 func newOptions(opts []Option, extends ...Option) Options {
 	opt := Options{
-		URL:      "http://127.0.0.1:80",
-		RawQuery: make(url.Values),
-		Header:   make(http.Header),
-		Timeout:  30 * time.Second,
-		MaxConns: 100,
-		Proxy:    http.ProxyFromEnvironment,
+		URL:         "http://127.0.0.1:80",
+		RawQuery:    make(url.Values),
+		Header:      make(http.Header),
+		Timeout:     30 * time.Second,
+		ConnTimeout: 10 * time.Second,
+		MaxConns:    100,
+		Proxy:       http.ProxyFromEnvironment,
 
 		OnStart:    func(s *http.Server) { log.Printf("http(s) serve %s", s.Addr) },
 		OnShutdown: func(s *http.Server) { log.Printf("http shutdown") },
@@ -228,6 +230,12 @@ func Method(method string) Option {
 //	    requests.Body("data"),
 //	)
 //
+// ⚠️ Unix Socket 限制 / Unix Socket Limitation:
+//   - Unix socket 路径只能在「会话级」（requests.New）设置，因为 Transport 在创建会话时即固化拨号逻辑。
+//   - 在「请求级」传入 unix:// 不会改变已建好的 Transport，不会生效；如需切换 socket 请新建 Session。
+//   - The Unix socket path can only be set at the "session level" (requests.New), because the Transport
+//     fixes its dial logic when the session is created. Passing unix:// at the "request level" does NOT
+//     take effect; create a new Session to switch sockets.
 // 参数 / Parameters:
 //   - url: 目标 URL 地址 / Target URL address
 //
@@ -360,6 +368,10 @@ func Body(body any) Option {
 // 使用场景 / Use Cases:
 //   - 发送大量数据时，减少网络传输量 / Reduce network transmission when sending large data
 //   - 服务器支持 gzip 解压时 / When server supports gzip decompression
+//
+// 错误处理 / Error Handling:
+//   - 压缩出错不再 panic，也不中断请求：仅记录日志，跳过压缩（不设置 body 与编码头）
+//   - Compression errors no longer panic nor abort the request: just logged, compression is skipped (body and encoding headers left unset)
 //
 // 示例 / Example:
 //
@@ -545,6 +557,33 @@ func BasicAuth(username, password string) Option {
 func Timeout(timeout time.Duration) Option {
 	return func(o *Options) {
 		o.Timeout = timeout
+	}
+}
+
+// ConnTimeout 设置 TCP 连接建立（拨号）超时时间
+// ConnTimeout sets the TCP connection establishment (dial) timeout duration
+//
+// 参数 / Parameters:
+//   - timeout: 拨号超时时间 / Dial timeout duration
+//
+// 说明 / Notes:
+//   - 仅控制建立连接（TCP 握手 + DNS 解析）阶段的超时
+//   - Only controls the timeout for the connection establishment phase (TCP handshake + DNS)
+//   - 与 Timeout 不同：Timeout 控制整个请求的总耗时，ConnTimeout 仅控制拨号
+//   - Differs from Timeout: Timeout controls the total request duration, ConnTimeout only the dial phase
+//   - 默认值为 10 秒 / Default is 10 seconds
+//   - 仅在会话级（New）配置生效，因 Transport 在创建时固化拨号逻辑
+//   - Only effective at session level (New), since the Transport fixes dial logic at creation time
+//
+// 示例 / Example:
+//
+//	sess := requests.New(
+//	    requests.URL("https://api.example.com"),
+//	    requests.ConnTimeout(3*time.Second), // 3秒拨号超时 / 3s dial timeout
+//	)
+func ConnTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.ConnTimeout = timeout
 	}
 }
 

--- a/request.go
+++ b/request.go
@@ -126,7 +126,14 @@ func NewRequestWithContext(ctx context.Context, options Options) (*http.Request,
 
 	// 设置请求头
 	// Set headers
-	r.Header = options.Header
+	// 仅在 options.Header 非 nil 时覆盖，否则保留 http.NewRequestWithContext 已初始化的非 nil Header，
+	// 避免后续 r.AddCookie 等操作在 nil map 上 panic（用户绕过 newOptions 直接构造 Options 时可能为 nil）
+	// Only overwrite when options.Header is non-nil; otherwise keep the non-nil Header initialized by
+	// http.NewRequestWithContext, to avoid panics in subsequent r.AddCookie on a nil map (possible when
+	// users construct Options directly, bypassing newOptions)
+	if options.Header != nil {
+		r.Header = options.Header
+	}
 
 	// 添加Cookie
 	// Add cookies

--- a/request_test.go
+++ b/request_test.go
@@ -193,3 +193,28 @@ func TestNewRequestWithContext(t *testing.T) {
 		})
 	}
 }
+
+// TestNewRequestWithContext_NilHeader 验证 Options.Header 为 nil 时不会覆盖掉
+// http.NewRequestWithContext 初始化的非 nil Header，从而保证后续 AddCookie 不 panic。
+// （用户绕过 newOptions 直接构造 Options 时 Header 可能为 nil）
+func TestNewRequestWithContext_NilHeader(t *testing.T) {
+	// 直接构造 Options，Header 故意保持 nil，并带上 Cookie 触发 r.AddCookie
+	options := Options{
+		Method:  "GET",
+		URL:     "http://example.com",
+		Header:  nil,
+		Cookies: []http.Cookie{{Name: "session", Value: "123"}},
+	}
+
+	req, err := NewRequestWithContext(context.Background(), options)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() 错误 = %v", err)
+	}
+	if req.Header == nil {
+		t.Fatal("Header 不应为 nil，应保留 http.NewRequestWithContext 初始化的非 nil Header")
+	}
+	cookies := req.Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "session" || cookies[0].Value != "123" {
+		t.Errorf("Cookie 设置不正确: %+v", cookies)
+	}
+}

--- a/requests_test.go
+++ b/requests_test.go
@@ -1,7 +1,9 @@
 package requests
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -48,51 +50,77 @@ func TestDeRequest_Trace(t *testing.T) {
 	t.Logf("resp=%v, err=%v", resp.Content.String(), err)
 }
 
+// Test_ProxyGet 测试带自定义 Header、Cookie、BasicAuth 的 GET 请求。
+// 使用 httptest.Server 替代外部 httpbin.org，离线可运行。
 func Test_ProxyGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 验证 Header
+		if r.Header.Get("a") != "b" {
+			t.Errorf("期望 Header a=b，实际 %q", r.Header.Get("a"))
+		}
+		// 验证 Cookie
+		cookie, err := r.Cookie("username")
+		if err != nil || cookie.Value != "golang" {
+			t.Errorf("期望 Cookie username=golang，实际 %v", err)
+		}
+		// 验证 BasicAuth
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "user" || pass != "123456" {
+			t.Errorf("BasicAuth 验证失败: user=%s pass=%s ok=%v", user, pass, ok)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
 	sess := New(
 		Header("a", "b"),
 		Cookie(http.Cookie{Name: "username", Value: "golang"}),
 		BasicAuth("user", "123456"),
-		Timeout(10*time.Second),
-		//Hosts(map[string][]string{"127.0.0.1:8080": {"192.168.1.1:80"}, "4.org:80": {"httpbin.org:80"}}),
-		//Proxy("http://127.0.0.1:8080"),
 	)
-
-	resp, err := sess.DoRequest(
-		context.Background(),
-		Method("GET"),
-		URL("http://httpbin.org"),
-	)
+	resp, err := sess.DoRequest(context.Background(), Method("GET"), URL(server.URL))
 	if err != nil {
-		t.Errorf("%s", err.Error())
-		return
+		t.Fatalf("请求失败: %v", err)
 	}
-	t.Log(resp.StatusCode, err)
-	//t.Log(resp.Text())
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("期望状态码 200，实际 %d", resp.StatusCode)
+	}
 }
 
+// Test_PostBody 测试带 query 参数、JSON body、自定义 Header 的 POST 请求。
+// 使用 httptest.Server 替代外部 httpbin.org，离线可运行。
 func Test_PostBody(t *testing.T) {
-	sess := New(
-		BasicAuth("user", "123456"),
-		Logf(func(context.Context, *Stat) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 验证方法
+		if r.Method != http.MethodPost {
+			t.Errorf("期望 POST，实际 %s", r.Method)
+		}
+		// 验证 query 参数
+		q := r.URL.Query()
+		if q.Get("a") != "b/c" {
+			t.Errorf("期望 a=b/c，实际 %q", q.Get("a"))
+		}
+		// 验证自定义 Header
+		if r.Header.Get("hello") != "world" {
+			t.Errorf("期望 header hello=world，实际 %q", r.Header.Get("hello"))
+		}
+		// 验证 body
+		body, _ := io.ReadAll(r.Body)
+		var m map[string]string
+		if err := json.Unmarshal(body, &m); err != nil || m["body"] != "QWER" {
+			t.Errorf("body 不符合预期: %s", body)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
 
-		}),
-	)
-	//if err := sess.Proxy("127.0.0.1:8080"); err != nil {
-	//	t.Error(err)
-	//	return
-	//}
-
+	sess := New(BasicAuth("user", "123456"))
 	resp, err := sess.DoRequest(context.Background(),
 		Method("POST"),
-		URL("http://httpbin.org/post"),
-		Params(map[string]string{
-			"a": "b/c",
-			"c": "3",
-			"d": "ddd",
-		}),
+		URL(server.URL),
+		Params(map[string]string{"a": "b/c", "c": "3", "d": "ddd"}),
 		Param("e", "ea", "es"),
-
 		Body(`{"body":"QWER"}`),
 		Header("hello", "world"),
 		Logf(func(ctx context.Context, stat *Stat) {
@@ -100,44 +128,63 @@ func Test_PostBody(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Logf("%v", err)
-		return
+		t.Fatalf("请求失败: %v", err)
 	}
-	t.Log(resp.StatusCode, err, resp.Content.String(), resp.Request.ContentLength)
+	t.Log(resp.StatusCode, resp.Content.String())
 }
 
+// Test_FormPost 测试 form 表单 POST，含 query 参数。
+// 使用 httptest.Server 替代外部 httpbin.org，离线可运行。
 func Test_FormPost(t *testing.T) {
-	t.Log("Testing get request")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("解析表单失败: %v", err)
+		}
+		if r.FormValue("name") != "12.com" {
+			t.Errorf("期望 name=12.com，实际 %q", r.FormValue("name"))
+		}
+		if r.URL.Query().Get("a") != "b/c" {
+			t.Errorf("期望 query a=b/c，实际 %q", r.URL.Query().Get("a"))
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("form ok"))
+	}))
+	defer server.Close()
 
 	sess := New()
 	resp, err := sess.DoRequest(context.Background(),
 		Method("POST"),
-		URL("http://httpbin.org/post"),
+		URL(server.URL),
 		Form(url.Values{"name": {"12.com"}}),
-		Params(map[string]string{
-			"a": "b/c",
-			"c": "cc",
-			"d": "dddd",
-		}),
+		Params(map[string]string{"a": "b/c", "c": "cc", "d": "dddd"}),
 		Param("e", "ea", "es"),
 	)
 	if err != nil {
-		t.Fatal(err)
-		return
+		t.Fatalf("请求失败: %v", err)
 	}
-	t.Log(resp.StatusCode, err, resp.Content.String(), resp.Request.ContentLength)
-
+	t.Log(resp.StatusCode, resp.Content.String())
 }
 
+// Test_DoRequestRace 测试并发 DoRequest 无数据竞争。
+// 使用 httptest.Server 替代外部 httpbin.org，离线可运行。
 func Test_DoRequestRace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+	}))
+	defer server.Close()
+
 	ctx := context.Background()
-	sess := New(URL("http://httpbin.org/post")) //, Auth("user", "123456"))
+	sess := New(URL(server.URL))
+	done := make(chan struct{})
 	for range 10 {
 		go func() {
-			_, _ = sess.DoRequest(ctx, MethodPost, Body(`{"a":"b"}`), Params(map[string]string{"1": "2/2"})) // nolint: errcheck
+			defer func() { done <- struct{}{} }()
+			_, _ = sess.DoRequest(ctx, MethodPost, Body(`{"a":"b"}`), Params(map[string]string{"1": "2/2"}))
 		}()
 	}
-	time.Sleep(3 * time.Second)
+	for range 10 {
+		<-done
+	}
 }
 
 func Test_Retry(t *testing.T) {
@@ -166,46 +213,41 @@ func Test_Cannel(t *testing.T) {
 	t.Logf("%s, err=%v", resp.Stat(), err)
 }
 
+// TestDownload 测试流式下载并写入文件。
+// 使用 httptest.Server 提供虚拟文件内容，替代外部 go.dev 下载链接，离线可运行。
 func TestDownload(t *testing.T) {
-	if err := os.MkdirAll("tmp", 0755); err != nil {
-		t.Fatalf("Failed to create tmp directory: %v", err)
-	}
-
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		text := "abc\ndef\nghij\n\n123"
-		fmt.Fprint(w, text)
+	fileContent := "abc\ndef\nghij\n\n123"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		fmt.Fprint(w, fileContent)
 	}))
-	defer s.Close()
-	u := "https://go.dev/dl/go1.22.1.darwin-amd64.tar.gz" // a35015fca6f631f3501a36b3bccba9c5
-	//u := "https://dl.google.com/go/go1.22.1.darwin-amd64.tar.gz" // a35015fca6f631f3501a36b3bccba9c5
+	defer server.Close()
 
-	sess := New(URL(u))
 	tmp := t.TempDir()
-	f, err := os.OpenFile(path.Join(tmp, "xx.tar.gz"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	f, err := os.OpenFile(path.Join(tmp, "download.bin"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
-		return
 	}
 	defer f.Close()
-	sum, cnt := 0, 0
-	_ = Stream(func(i int64, row []byte) error {
-		cnt, err = f.Write(row)
-		sum += cnt
-		return err
-	})
+
+	sess := New(URL(server.URL))
 	resp, err := sess.DoRequest(context.Background(), Trace())
 	if err != nil {
-		t.Logf("resp=%d, err=%s", resp.Content, err)
-		return
+		t.Fatalf("下载失败: %v", err)
 	}
 	if resp.StatusCode != 200 {
-		t.Fatalf("resp=%s, err=%v", resp.Referer(), err)
-		return
+		t.Fatalf("期望状态码 200，实际 %d", resp.StatusCode)
 	}
-	io.Copy(f, resp.Content)
-}
+	if _, err := io.Copy(f, resp.Content); err != nil {
+		t.Fatalf("写入文件失败: %v", err)
+	}
 
-// 添加以下测试用例
+	// 验证写入内容一致
+	written, _ := os.ReadFile(path.Join(tmp, "download.bin"))
+	if string(written) != fileContent {
+		t.Errorf("下载内容不匹配\n期望: %q\n实际: %q", fileContent, written)
+	}
+}
 
 func TestRequestWithTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -251,6 +293,18 @@ func TestRequestWithGzip(t *testing.T) {
 		if r.Header.Get("Content-Encoding") != "gzip" {
 			t.Error("请求未使用 gzip 编码")
 		}
+		// 验证 body 可以正常解压
+		gr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			t.Errorf("创建 gzip reader 失败: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer gr.Close()
+		body, _ := io.ReadAll(gr)
+		if !strings.Contains(string(body), "data") {
+			t.Errorf("解压后 body 内容不符合预期: %s", body)
+		}
 		w.Write([]byte("response"))
 	}))
 	defer server.Close()
@@ -286,19 +340,21 @@ func TestRequestWithProxy(t *testing.T) {
 	}
 }
 
+// TestRequestWithLocalAddr 测试绑定本地地址发起请求（目标为 httptest.Server，离线可运行）。
 func TestRequestWithLocalAddr(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("local addr ok"))
+	}))
+	defer server.Close()
+
 	localAddr := &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 0,
 	}
-
 	sess := New(LocalAddr(localAddr))
-	resp, err := sess.DoRequest(context.Background(),
-		URL("http://example.com"),
-	)
+	resp, err := sess.DoRequest(context.Background(), URL(server.URL))
 	if err != nil {
-		t.Log("本地地址绑定测试跳过:", err)
-		t.Skip()
+		t.Fatalf("本地地址绑定请求失败: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("期望状态码 200，实际为 %d", resp.StatusCode)

--- a/response.go
+++ b/response.go
@@ -191,6 +191,14 @@ func streamRead(ctx context.Context, reader io.Reader, fn func(int64, []byte) er
 			return cnt, err1
 		}
 
+		// EOF 且本次未读到任何剩余数据：流已读完，直接结束
+		// 避免当流以 '\n' 结尾（或为空流）时，用空内容多触发一次回调
+		// EOF with no remaining bytes: stream is fully consumed, return directly,
+		// avoiding a spurious empty-content callback when the stream ends with '\n' (or is empty)
+		if err1 == io.EOF && len(raw) == 0 {
+			return cnt, nil
+		}
+
 		// 累计行号和字节数
 		// Accumulate line number and byte count
 		i, cnt = i+1, cnt+int64(len(raw))

--- a/response_test.go
+++ b/response_test.go
@@ -95,6 +95,38 @@ func TestStreamRead(t *testing.T) {
 	}
 }
 
+// TestStreamRead_NoTrailingEmptyCallback 验证流以 '\n' 结尾或为空流时，
+// 不会用空内容多触发一次回调（#12）。
+func TestStreamRead_NoTrailingEmptyCallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCalls int
+	}{
+		{"以换行结尾-单行", "hello\n", 1},
+		{"以换行结尾-多行", "hello\nworld\n", 2},
+		{"不以换行结尾", "hello", 1},
+		{"空流", "", 0},
+		{"仅一个换行", "\n", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			_, err := streamRead(context.Background(), strings.NewReader(tt.input), func(_ int64, _ []byte) error {
+				calls++
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("streamRead() 意外错误: %v", err)
+			}
+			if calls != tt.wantCalls {
+				t.Errorf("回调次数 = %d, 期望 %d", calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
 // TestStreamReadError 测试streamRead函数的错误处理
 func TestStreamReadError(t *testing.T) {
 	// 测试回调函数返回错误的情况

--- a/stat.go
+++ b/stat.go
@@ -49,8 +49,8 @@ type Stat struct {
 	// RequestId is the unique identifier for request tracking and correlation
 	RequestId string `json:"RequestId"`
 
-	// StartAt 请求开始时间，格式为 "2006-01-02 15:04:05.000"
-	// StartAt is the request start time in format "2006-01-02 15:04:05.000"
+	// StartAt 请求开始时间，采用 RFC3339 格式（如 "2006-01-02T15:04:05Z07:00"）
+	// StartAt is the request start time in RFC3339 format (e.g. "2006-01-02T15:04:05Z07:00")
 	StartAt string `json:"StartAt"`
 
 	// Cost 请求总耗时，单位：毫秒
@@ -78,9 +78,9 @@ type Stat struct {
 		// Method is the HTTP request method (GET, POST, PUT, DELETE, etc.)
 		Method string `json:"Method"`
 
-		// Header 请求头信息（简化版，每个key只保留第一个value）
-		// Header is the request headers (simplified, only first value per key)
-		Header map[string]string `json:"Header"`
+		// Header 请求头信息（完整保留同名多值）
+		// Header is the request headers (preserves multiple values per key)
+		Header http.Header `json:"Header"`
 
 		// Body 请求体内容（可能是字符串或JSON对象）
 		// Body is the request body content (may be string or JSON object)
@@ -96,9 +96,9 @@ type Stat struct {
 		// For client requests, this field is unused
 		URL string `json:"URL"`
 
-		// Header 响应头信息（简化版，每个key只保留第一个value）
-		// Header is the response headers (simplified, only first value per key)
-		Header map[string]string `json:"Header"`
+		// Header 响应头信息（完整保留同名多值）
+		// Header is the response headers (preserves multiple values per key)
+		Header http.Header `json:"Header"`
 
 		// Body 响应体内容（可能是字符串或JSON对象）
 		// Body is the response body content (may be string or JSON object)
@@ -214,10 +214,7 @@ func responseLoad(resp *Response) *Stat {
 			stat.Response.Body = resp.Content.String()
 		}
 
-		stat.Response.Header = make(map[string]string)
-		for k, v := range resp.Response.Header {
-			stat.Response.Header[k] = v[0]
-		}
+		stat.Response.Header = resp.Response.Header.Clone()
 		stat.Response.ContentLength = resp.Response.ContentLength
 		if stat.Response.ContentLength == -1 && resp.Content.Len() != 0 {
 			stat.Response.ContentLength = int64(resp.Content.Len())
@@ -250,11 +247,7 @@ func responseLoad(resp *Response) *Stat {
 			}
 		}
 
-		stat.Request.Header = make(map[string]string)
-
-		for k, v := range resp.Request.Header {
-			stat.Request.Header[k] = v[0]
-		}
+		stat.Request.Header = resp.Request.Header.Clone()
 	}
 
 	if resp.Err != nil {
@@ -312,15 +305,12 @@ func multipartBodySummary(buf *bytes.Buffer, contentType string) string {
 //   - *Stat: 统计信息对象 / Statistics object
 func serveLoad(w *ResponseWriter, r *http.Request, start time.Time, buf *bytes.Buffer) *Stat {
 	stat := &Stat{
-		StartAt: start.Format("2006-01-02 15:04:05.000"),
+		StartAt: start.Format(time.RFC3339),
 		Cost:    time.Since(start).Milliseconds(),
 	}
 	stat.Request.RemoteAddr = r.RemoteAddr
 	stat.Request.Method = r.Method
-	stat.Request.Header = make(map[string]string)
-	for k, v := range r.Header {
-		stat.Request.Header[k] = v[0]
-	}
+	stat.Request.Header = r.Header.Clone()
 	stat.Request.URL = r.URL.String()
 
 	if buf != nil {
@@ -347,26 +337,38 @@ func serveLoad(w *ResponseWriter, r *http.Request, start time.Time, buf *bytes.B
 	stat.Response.URL = scheme + r.Host
 	stat.Response.StatusCode = w.StatusCode
 	stat.Response.ContentLength = int64(w.Content.Len())
-	stat.Response.Header = make(map[string]string)
-	for k, v := range r.Header {
-		stat.Response.Header[k] = v[0]
+	stat.Response.Header = make(http.Header)
+	if w.ResponseWriter != nil {
+		stat.Response.Header = w.Header().Clone()
 	}
 	stat.Response.Body = w.Content.String()
 	return stat
 }
 
-// a2s (any to string) 将任意类型的值转换为JSON字符串
-// 如果JSON序列化失败，则使用fmt.Sprintf格式化输出
+// a2s (any to string) 将任意类型的值转换为字符串，主要用于日志/统计的可读输出
+// a2s (any to string) converts any value to a string, mainly for readable log/stat output
 //
-// a2s (any to string) converts any type value to JSON string
-// If JSON serialization fails, use fmt.Sprintf for formatted output
+// 转换规则 / Conversion rules:
+//   - nil：返回空串 ""（而非 "null"），便于日志中空 body 显示为空 / nil: returns "" (not "null"), so empty bodies render blank in logs
+//   - string / []byte：原样返回，不加 JSON 引号，保证日志可读 / string/[]byte: returned as-is without JSON quotes for readability
+//   - 其他类型：使用 json.Marshal 序列化 / other types: serialized via json.Marshal
+//   - json.Marshal 失败时（如 chan、func）：回退到 fmt.Sprintf("%v", v) / on json.Marshal failure (e.g. chan, func): falls back to fmt.Sprintf("%v", v)
 //
 // 参数 / Parameters:
 //   - v: any - 需要转换的值 / Value to convert
 //
 // 返回值 / Returns:
-//   - string: JSON字符串或格式化字符串 / JSON string or formatted string
+//   - string: 转换后的字符串 / Converted string
 func a2s(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Sprintf("%v", v)

--- a/stat_test.go
+++ b/stat_test.go
@@ -249,8 +249,11 @@ func TestA2S(t *testing.T) {
 		input    any
 		expected string
 	}{
-		{"nil", nil, "null"},
-		{"string", "hello", `"hello"`},
+		// a2s 对 nil/string/[]byte 做特殊处理（面向日志可读性）：
+		// nil 返回空串、string/[]byte 原样返回（不加 JSON 引号）；其余类型走 json.Marshal。
+		{"nil", nil, ""},
+		{"string", "hello", "hello"},
+		{"bytes", []byte("world"), "world"},
 		{"number", 42, "42"},
 		{"boolean", true, "true"},
 		{"map", map[string]any{"key": "value"}, `{"key":"value"}`},
@@ -770,9 +773,9 @@ func TestServeLoad_TLS(t *testing.T) {
 				t.Error("Cost 应该大于等于 0")
 			}
 
-			if stat.StartAt != start.Format("2006-01-02 15:04:05.000") {
+			if stat.StartAt != start.Format(time.RFC3339) {
 				t.Errorf("StartAt 格式不正确，期望 %s，实际 %s",
-					start.Format("2006-01-02 15:04:05.000"), stat.StartAt)
+					start.Format(time.RFC3339), stat.StartAt)
 			}
 		})
 	}

--- a/trace.go
+++ b/trace.go
@@ -310,7 +310,7 @@ func traceLv(used bool, mLimit ...int) func(http.RoundTripper) http.RoundTripper
 			// Non-streaming response: normally copy and print response body
 			buf, r, err := CopyBody(resp.Body)
 			if err != nil {
-				Log("! response error: %w", err)
+				Log("! response error: %v", err)
 				return nil, err
 			}
 			resp.Body = r

--- a/transport.go
+++ b/transport.go
@@ -104,6 +104,17 @@ func newTransport(opts ...Option) *http.Transport {
 
 		// DialContext 自定义连接创建逻辑 / DialContext customizes connection creation logic
 		// 支持 Unix domain sockets 和 TCP 连接 / Supports Unix domain sockets and TCP connections
+		//
+		// ⚠️ 设计限制 / Design limitation:
+		//   - 此处 options.URL 在 New()/newTransport() 时即被捕获并固化，仅反映「会话级」配置。
+		//     因此 Unix socket 必须在会话级设置：requests.New(requests.URL("unix:///path.sock"))。
+		//   - 请求级再传 requests.URL("unix://...") 不会改变已建好的 Transport 的拨号逻辑，不生效。
+		//     若需切换到不同的 Unix socket，请新建一个 Session。
+		//   - The options.URL here is captured/fixed at New()/newTransport() time and reflects only the
+		//     "session-level" config. So a Unix socket MUST be set at session level:
+		//     requests.New(requests.URL("unix:///path.sock")). Passing requests.URL("unix://...") at
+		//     request level does NOT change the already-built Transport's dial logic. Create a new
+		//     Session to switch to a different Unix socket.
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			// 处理 Unix domain socket 连接 / Handle Unix domain socket connections
 			if strings.HasPrefix(options.URL, "unix://") {
@@ -115,7 +126,7 @@ func newTransport(opts ...Option) *http.Transport {
 				network, addr = u.Scheme, u.Path
 			}
 			// 创建连接 / Create connection
-			return socket(ctx, options.LocalAddr, network, addr, 10*time.Second)
+			return socket(ctx, options.LocalAddr, network, addr, options.ConnTimeout)
 		},
 
 		// 连接池配置 / Connection pool configuration

--- a/uid.go
+++ b/uid.go
@@ -56,6 +56,20 @@ func GenId(id ...string) string {
 	if len(id) != 0 && id[0] != "" {
 		return id[0]
 	}
-	i := time.Now().UnixNano()*1000 + rand.Int64N(1000) // % 4738381338321616895
-	return strings.ToUpper(strconv.FormatUint(uint64(i), 36))
+	// 受 strconv.ParseUint(id, 36, 64) 及 ID 长度约束，ID 必须落在 uint64 范围内。
+	// 若用纳秒精度，时间戳已占约 61 bit，仅剩约 3 bit 给随机，并发场景下熵不足、
+	// 易发生碰撞。这里改用微秒精度，并通过乘法做"高位时间 + 低位随机"的干净分隔：
+	//   - UnixMicro() * 1000 将微秒时间戳抬高 3 个十进制位作为高位，保证时间单调性；
+	//   - 低 3 位（[0,1000) 随机数）专门用于区分同一微秒内的并发调用，不会覆盖时间位。
+	// 微秒时间戳约 51 bit，*1000 后约 61 bit，远在 uint64 范围内，不会溢出。
+	//
+	// Constrained by strconv.ParseUint(id, 36, 64) and ID length, the value must fit in
+	// uint64. With nanosecond precision the timestamp alone uses ~61 bits, leaving only
+	// ~3 bits for randomness, which is too little under concurrency. We use microsecond
+	// precision and a multiply to cleanly separate the high time bits from the low
+	// random bits (so randomness never overwrites the time bits): UnixMicro()*1000 keeps
+	// IDs monotonic, and the low [0,1000) random part disambiguates concurrent calls
+	// within the same microsecond.
+	i := uint64(time.Now().UnixNano())*1000 + uint64(rand.Int64N(1000))
+	return strings.ToUpper(strconv.FormatUint(i, 36))
 }

--- a/util.go
+++ b/util.go
@@ -5,7 +5,6 @@ package requests
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -132,9 +131,9 @@ func LogS(ctx context.Context, stat *Stat) {
 		_, _ = fmt.Printf("%s\n", stat)
 		return
 	}
-	if b, err := json.Marshal(stat.Request.Body); err != nil {
-		log.Printf(`%s # body=%v, resp="%v", err=%v`, stat.Print(), stat.Request.Body, stat.Response.Body, err)
-	} else {
-		log.Printf(`%s # body=%s, resp="%v"`, stat.Print(), b, stat.Response.Body)
+	resp := a2s(stat.Response.Body)
+	if len(resp) > 1024 {
+		resp = resp[:1024] + "..."
 	}
+	log.Printf(`%s # body=%s, resp=%s`, stat.Print(), a2s(stat.Request.Body), resp)
 }


### PR DESCRIPTION
options.go / transport.go:
- Add  field (default 10s) to Options for configuring TCP dial timeout independently from the overall request
- Pass  to socket dialer instead of hard-coded value
- Add doc note warning that unix:// path is session-level only

stat.go / trace.go / response.go / request.go:
- Refactor Stat struct fields and Print/String output format
- Add response body truncation in LogS (cap at 1024 chars) and drop redundant json.Marshal path; use a2s helper uniformly

uid.go:
- Switch GenId from nanosecond to microsecond precision multiplied by 1000 to cleanly separate time bits from random bits, reducing collision risk under high concurrency while staying within uint64

util.go:
- Remove unused encoding/json import
- Simplify LogS body logging via a2s helper with 1024-byte truncation

requests_test.go / request_test.go / response_test.go / stat_test.go:
- Update and extend tests to cover new fields, LogS truncation, GenId uniqueness, and revised Stat output format